### PR TITLE
Fix bug identified on Shopware's Ci on TypePHP's end

### DIFF
--- a/src/Contract/ContractParser.php
+++ b/src/Contract/ContractParser.php
@@ -559,6 +559,7 @@ final class ContractParser
         $baseParamNames = [];
         $baseParamSet = [];
         $baseParamVariadic = [];
+        $isConstructor = ($ref->getName() === '__construct');
 
         foreach ($baseParams as $idx => $p) {
             $baseParamNames[$idx] = $p->getName();
@@ -597,7 +598,13 @@ final class ContractParser
             $paramTags = DocblockExtractor::getParamTags($phpDocNode);
 
             foreach ($paramTags as $paramName => $paramTag) {
-                $targetParamName = self::resolveTargetParamName($paramName, $baseParamSet, $baseParamNames, $hierNameToIndex);
+                $targetParamName = self::resolveTargetParamName(
+                    $paramName,
+                    $baseParamSet,
+                    $baseParamNames,
+                    $hierNameToIndex,
+                    $isConstructor
+                );
 
                 if ($targetParamName !== null && ! isset($types[$targetParamName])) {
                     $type = $paramTag->type;
@@ -631,10 +638,15 @@ final class ContractParser
         string $paramName,
         array $baseParamSet,
         array $baseParamNames,
-        array $hierNameToIndex
+        array $hierNameToIndex,
+        bool $isConstructor = false
     ): ?string {
         if (isset($baseParamSet[$paramName])) {
             return $paramName;
+        }
+
+        if ($isConstructor) {
+            return null;
         }
 
         $paramIndex = $hierNameToIndex[$paramName] ?? null;

--- a/tests/Fixtures/Shopware/Exception/BaseShopwareExceptionFixture.php
+++ b/tests/Fixtures/Shopware/Exception/BaseShopwareExceptionFixture.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypePHP\Tests\Fixtures\Shopware\Exception;
+
+abstract class BaseShopwareExceptionFixture extends \Exception
+{
+    /**
+     * @param string $message
+     * @param array<string, mixed> $parameters
+     * @param \Throwable|null $e
+     */
+    public function __construct(
+        string $message,
+        array $parameters = [],
+        ?\Throwable $e = null
+    ) {
+        parent::__construct($message, 0, $e);
+    }
+}

--- a/tests/Fixtures/Shopware/Exception/TableHelperExceptionFixture.php
+++ b/tests/Fixtures/Shopware/Exception/TableHelperExceptionFixture.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TypePHP\Tests\Fixtures\Shopware\Exception;
+
+class TableHelperExceptionFixture extends BaseShopwareExceptionFixture
+{
+    public function __construct(
+        string $message,
+        ?\Throwable $previousException = null
+    ) {
+        parent::__construct($message, [], $previousException);
+    }
+}

--- a/tests/TypeChecking/InheritanceAndAttributes/ConstructorInheritanceMismatchTest.php
+++ b/tests/TypeChecking/InheritanceAndAttributes/ConstructorInheritanceMismatchTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use TypePHP\Tests\Fixtures\Shopware\Exception\TableHelperExceptionFixture;
+
+describe('Constructor Parameter Inheritance Mismatch (Shopware TableHelperException)', function () {
+    test('child constructor with different parameter names does not inherit parent constructor docblocks by positional index', function () {
+        $previous = new \Exception('Underlying DB error');
+
+        $exception = new TableHelperExceptionFixture('Table missing', $previous);
+
+        expect($exception)->toBeInstanceOf(TableHelperExceptionFixture::class)
+            ->and($exception->getPrevious())->toBe($previous);
+    });
+});


### PR DESCRIPTION
In PHP, constructors do not follow LSP and child classes often declare completely different constructor parameters than their parents. 

Previously, `ContractParser::resolveTargetParamName()` used positional index fallback to map missing parameter docblocks from parent constructors to child constructors. In frameworks like Shopware, this caused parent constructor docblocks (e.g. `@param array $parameters` at index 1) to be incorrectly mapped onto child parameters (e.g. `?\Throwable $previousException` at index 1), throwing false `TypeError` exceptions.

* Disabled positional index fallback for `__construct()` methods in `ContractParser`.
* Child constructors now only inherit docblocks from parent constructors if the parameter names match explicitly.
* Normal methods continue to support positional renaming for LSP method overriding.
